### PR TITLE
Fixed: broken javascript filepaths

### DIFF
--- a/Web Page/Pages/Assistance Programs - ED3.html
+++ b/Web Page/Pages/Assistance Programs - ED3.html
@@ -19,7 +19,7 @@
 		<!-- <base href="http://www.ed3online.org/"> -->
 		<meta charset="utf-8">
 		<title>Assistance Programs | Electrical District #3</title>
-		<script type="text/javascript" src="./JS/Scroll%20Button.js"></script>
+		<script type="text/javascript" src="../JS/Scroll%20Button.js"></script>
 	</head>
 	
 	<!-- Background implemented -->

--- a/Web Page/Pages/Board Agenda - ED3.html
+++ b/Web Page/Pages/Board Agenda - ED3.html
@@ -19,7 +19,7 @@
 		<!-- <base href="http://www.ed3online.org/"> -->
 		<meta charset="utf-8">
 		<title>Board Agenda | Electrical District #3</title>
-		<script type="text/javascript" src="./JS/Scroll%20Button.js"></script>
+		<script type="text/javascript" src="../JS/Scroll%20Button.js"></script>
 	</head>
 	
 	<!-- Background implemented -->

--- a/Web Page/Pages/NEWS - ED3.html
+++ b/Web Page/Pages/NEWS - ED3.html
@@ -19,7 +19,7 @@
 		<!-- <base href="http://www.ed3online.org/"> -->
 		<meta charset="utf-8">
 		<title>News | Electrical District #3</title>
-		<script type="text/javascript" src="./JS/Scroll%20Button.js"></script>
+		<script type="text/javascript" src="../JS/Scroll%20Button.js"></script>
 	</head>
 	
 	<!-- Background implemented -->

--- a/Web Page/Pages/Prevent Power Theft - ED3.html
+++ b/Web Page/Pages/Prevent Power Theft - ED3.html
@@ -19,7 +19,7 @@
 		<!-- <base href="http://www.ed3online.org/"> -->
 		<meta charset="utf-8">
 		<title>Power Theft Prevention | Electrical District #3</title>
-		<script type="text/javascript" src="./JS/Scroll%20Button.js"></script>
+		<script type="text/javascript" src="../JS/Scroll%20Button.js"></script>
 	</head>
 	
 	<!-- Background implemented -->

--- a/Web Page/Pages/Questions - ED3.html
+++ b/Web Page/Pages/Questions - ED3.html
@@ -19,7 +19,7 @@
 		<!-- <base href="http://www.ed3online.org/"> -->
 		<meta charset="utf-8">
 		<title>Questions | Electrical District #3</title>
-		<script type="text/javascript" src="./JS/Scroll%20Button.js"></script>
+		<script type="text/javascript" src="../JS/Scroll%20Button.js"></script>
 	</head>
 	
 	<!-- Background implemented -->


### PR DESCRIPTION
Edited html in each file to point to the correct javascript file path.
File paths for javascript files in these pages were incorrectly referencing the current folder instead of the parent folder, and thus unable to locate the JS folder.
Old: src="./JS"
New: src="../JS"